### PR TITLE
Support for WhatsApp Business Alongside Regular WhatsApp

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,5 +46,6 @@
 
     <queries>
         <package android:name="com.whatsapp" />
+        <package android:name="com.whatsapp.w4b" />
     </queries>
 </manifest>

--- a/app/src/main/java/dev/theolm/wwc/data/datasource/AppDataStore.kt
+++ b/app/src/main/java/dev/theolm/wwc/data/datasource/AppDataStore.kt
@@ -1,6 +1,7 @@
 package dev.theolm.wwc.data.datasource
 
 import androidx.datastore.core.DataStore
+import dev.theolm.wwc.domain.models.AppSettings
 import kotlinx.coroutines.flow.Flow
 
 const val DataStoreFileName = "app_settings.json"

--- a/app/src/main/java/dev/theolm/wwc/data/repository/AppSettingsRepositoryImpl.kt
+++ b/app/src/main/java/dev/theolm/wwc/data/repository/AppSettingsRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package dev.theolm.wwc.data.repository
 
 import dev.theolm.wwc.data.datasource.AppDataStore
-import dev.theolm.wwc.data.datasource.AppSettings
+import dev.theolm.wwc.domain.models.AppSettings
 import dev.theolm.wwc.domain.repository.AppSettingsRepository
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/java/dev/theolm/wwc/di/DiModules.kt
+++ b/app/src/main/java/dev/theolm/wwc/di/DiModules.kt
@@ -98,7 +98,8 @@ val presentationModule = module {
 
     viewModel {
         InputDialogViewModel(
-            appDataStore = get()
+            observeSelectedAppUseCase = get(),
+            observeSelectedCountryUseCase = get()
         )
     }
 }

--- a/app/src/main/java/dev/theolm/wwc/di/DiModules.kt
+++ b/app/src/main/java/dev/theolm/wwc/di/DiModules.kt
@@ -11,10 +11,14 @@ import dev.theolm.wwc.data.repository.AppSettingsRepositoryImpl
 import dev.theolm.wwc.domain.models.AppSettings
 import dev.theolm.wwc.domain.models.AppSettingsSerializer
 import dev.theolm.wwc.domain.repository.AppSettingsRepository
+import dev.theolm.wwc.domain.usecase.ObserveSelectedAppUseCase
+import dev.theolm.wwc.domain.usecase.ObserveSelectedAppUseCaseImpl
 import dev.theolm.wwc.domain.usecase.ObserveSelectedCountryUseCase
 import dev.theolm.wwc.domain.usecase.ObserveSelectedCountryUseCaseImpl
 import dev.theolm.wwc.domain.usecase.ObserveSettingsUseCase
 import dev.theolm.wwc.domain.usecase.ObserveSettingsUseCaseImpl
+import dev.theolm.wwc.domain.usecase.UpdateSelectedAppUseCase
+import dev.theolm.wwc.domain.usecase.UpdateSelectedAppUseCaseImpl
 import dev.theolm.wwc.domain.usecase.UpdateSelectedCountryUseCase
 import dev.theolm.wwc.domain.usecase.UpdateSelectedCountryUseCaseImpl
 import dev.theolm.wwc.domain.usecase.UpdateSettingsUseCase
@@ -54,8 +58,16 @@ val domainModule = module {
         ObserveSettingsUseCaseImpl(repository = get())
     }
 
+    factory<ObserveSelectedAppUseCase> {
+        ObserveSelectedAppUseCaseImpl(repository = get())
+    }
+
     factory<UpdateSelectedCountryUseCase> {
         UpdateSelectedCountryUseCaseImpl(repository = get())
+    }
+
+    factory<UpdateSelectedAppUseCase> {
+        UpdateSelectedAppUseCaseImpl(repository = get())
     }
 
     factory<UpdateSettingsUseCase> {
@@ -73,7 +85,8 @@ val presentationModule = module {
 
     viewModel {
         DefaultAppViewModel(
-            observeSettingsUseCase = get(),
+            observeSelectedAppUseCase = get(),
+            updateSelectedAppUseCase = get()
         )
     }
 

--- a/app/src/main/java/dev/theolm/wwc/di/DiModules.kt
+++ b/app/src/main/java/dev/theolm/wwc/di/DiModules.kt
@@ -6,16 +6,21 @@ import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.dataStoreFile
 import dev.theolm.wwc.data.datasource.AppDataStore
 import dev.theolm.wwc.data.datasource.AppDataStoreImpl
-import dev.theolm.wwc.data.datasource.AppSettings
-import dev.theolm.wwc.data.datasource.AppSettingsSerializer
 import dev.theolm.wwc.data.datasource.DataStoreFileName
 import dev.theolm.wwc.data.repository.AppSettingsRepositoryImpl
+import dev.theolm.wwc.domain.models.AppSettings
+import dev.theolm.wwc.domain.models.AppSettingsSerializer
 import dev.theolm.wwc.domain.repository.AppSettingsRepository
 import dev.theolm.wwc.domain.usecase.ObserveSelectedCountryUseCase
 import dev.theolm.wwc.domain.usecase.ObserveSelectedCountryUseCaseImpl
+import dev.theolm.wwc.domain.usecase.ObserveSettingsUseCase
+import dev.theolm.wwc.domain.usecase.ObserveSettingsUseCaseImpl
 import dev.theolm.wwc.domain.usecase.UpdateSelectedCountryUseCase
 import dev.theolm.wwc.domain.usecase.UpdateSelectedCountryUseCaseImpl
+import dev.theolm.wwc.domain.usecase.UpdateSettingsUseCase
+import dev.theolm.wwc.domain.usecase.UpdateSettingsUseCaseImpl
 import dev.theolm.wwc.presentation.ui.main.dialog.input.InputDialogViewModel
+import dev.theolm.wwc.presentation.ui.settings.defaultapp.DefaultAppViewModel
 import dev.theolm.wwc.presentation.ui.settings.defaultcode.DefaultCodeViewModel
 import dev.theolm.wwc.presentation.ui.settings.home.SettingsViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -45,8 +50,16 @@ val domainModule = module {
         ObserveSelectedCountryUseCaseImpl(repository = get())
     }
 
+    factory<ObserveSettingsUseCase> {
+        ObserveSettingsUseCaseImpl(repository = get())
+    }
+
     factory<UpdateSelectedCountryUseCase> {
         UpdateSelectedCountryUseCaseImpl(repository = get())
+    }
+
+    factory<UpdateSettingsUseCase> {
+        UpdateSettingsUseCaseImpl(repository = get())
     }
 }
 
@@ -59,8 +72,14 @@ val presentationModule = module {
     }
 
     viewModel {
+        DefaultAppViewModel(
+            observeSettingsUseCase = get(),
+        )
+    }
+
+    viewModel {
         SettingsViewModel(
-            observeSelectedCountry = get(),
+            observeSettings = get(),
         )
     }
 

--- a/app/src/main/java/dev/theolm/wwc/domain/models/AppSettings.kt
+++ b/app/src/main/java/dev/theolm/wwc/domain/models/AppSettings.kt
@@ -1,8 +1,7 @@
-package dev.theolm.wwc.data.datasource
+package dev.theolm.wwc.domain.models
 
 import android.util.Log
 import androidx.datastore.core.Serializer
-import dev.theolm.wwc.domain.models.Country
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -12,6 +11,7 @@ import java.io.OutputStream
 @Serializable
 data class AppSettings(
     val selectedCountryCode: Country? = null,
+    val defaultApp: DefaultApp = DefaultApp.WhatsApp
 )
 
 @Suppress("BlockingMethodInNonBlockingContext")

--- a/app/src/main/java/dev/theolm/wwc/domain/models/DefaultApp.kt
+++ b/app/src/main/java/dev/theolm/wwc/domain/models/DefaultApp.kt
@@ -1,0 +1,10 @@
+package dev.theolm.wwc.domain.models
+
+import dev.theolm.wwc.util.WhatsAppPackages
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class DefaultApp(val bundleId: String) {
+    WhatsApp(WhatsAppPackages.Whatsapp),
+    WhatsAppBusiness(WhatsAppPackages.WhatsappBuisness),
+}

--- a/app/src/main/java/dev/theolm/wwc/domain/repository/AppSettingsRepository.kt
+++ b/app/src/main/java/dev/theolm/wwc/domain/repository/AppSettingsRepository.kt
@@ -1,6 +1,6 @@
 package dev.theolm.wwc.domain.repository
 
-import dev.theolm.wwc.data.datasource.AppSettings
+import dev.theolm.wwc.domain.models.AppSettings
 import kotlinx.coroutines.flow.Flow
 
 interface AppSettingsRepository {

--- a/app/src/main/java/dev/theolm/wwc/domain/usecase/ObserveSelectedAppUseCase.kt
+++ b/app/src/main/java/dev/theolm/wwc/domain/usecase/ObserveSelectedAppUseCase.kt
@@ -1,0 +1,16 @@
+package dev.theolm.wwc.domain.usecase
+
+import dev.theolm.wwc.domain.models.DefaultApp
+import dev.theolm.wwc.domain.repository.AppSettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+interface ObserveSelectedAppUseCase {
+    operator fun invoke(): Flow<DefaultApp>
+}
+
+internal class ObserveSelectedAppUseCaseImpl(
+    private val repository: AppSettingsRepository,
+) : ObserveSelectedAppUseCase {
+    override fun invoke() = repository.getAppSettings().map { it.defaultApp }
+}

--- a/app/src/main/java/dev/theolm/wwc/domain/usecase/ObserveSettingsUseCase.kt
+++ b/app/src/main/java/dev/theolm/wwc/domain/usecase/ObserveSettingsUseCase.kt
@@ -1,0 +1,15 @@
+package dev.theolm.wwc.domain.usecase
+
+import dev.theolm.wwc.domain.models.AppSettings
+import dev.theolm.wwc.domain.repository.AppSettingsRepository
+import kotlinx.coroutines.flow.Flow
+
+interface ObserveSettingsUseCase {
+    operator fun invoke(): Flow<AppSettings>
+}
+
+internal class ObserveSettingsUseCaseImpl(
+    private val repository: AppSettingsRepository,
+) : ObserveSettingsUseCase {
+    override fun invoke() = repository.getAppSettings()
+}

--- a/app/src/main/java/dev/theolm/wwc/domain/usecase/UpdateSelectedAppUseCase.kt
+++ b/app/src/main/java/dev/theolm/wwc/domain/usecase/UpdateSelectedAppUseCase.kt
@@ -1,0 +1,22 @@
+package dev.theolm.wwc.domain.usecase
+
+import dev.theolm.wwc.domain.models.DefaultApp
+import dev.theolm.wwc.domain.repository.AppSettingsRepository
+import kotlinx.coroutines.flow.first
+
+interface UpdateSelectedAppUseCase {
+    suspend operator fun invoke(selectedApp: DefaultApp)
+}
+
+internal class UpdateSelectedAppUseCaseImpl(
+    private val repository: AppSettingsRepository,
+) : UpdateSelectedAppUseCase {
+    override suspend fun invoke(selectedApp: DefaultApp) {
+        val appSettings = repository.getAppSettings().first()
+        repository.updateAppSettings(
+            appSettings = appSettings.copy(
+                defaultApp = selectedApp
+            )
+        )
+    }
+}

--- a/app/src/main/java/dev/theolm/wwc/domain/usecase/UpdateSettingsUseCase.kt
+++ b/app/src/main/java/dev/theolm/wwc/domain/usecase/UpdateSettingsUseCase.kt
@@ -1,0 +1,16 @@
+package dev.theolm.wwc.domain.usecase
+
+import dev.theolm.wwc.domain.models.AppSettings
+import dev.theolm.wwc.domain.repository.AppSettingsRepository
+
+interface UpdateSettingsUseCase {
+    suspend operator fun invoke(update: AppSettings)
+}
+
+internal class UpdateSettingsUseCaseImpl(
+    private val repository: AppSettingsRepository,
+) : UpdateSettingsUseCase {
+    override suspend fun invoke(update: AppSettings) {
+        repository.updateAppSettings(appSettings = update)
+    }
+}

--- a/app/src/main/java/dev/theolm/wwc/presentation/extensions/ActivityExt.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/extensions/ActivityExt.kt
@@ -7,9 +7,13 @@ import android.net.Uri
 private const val WhatsappUri = "https://api.whatsapp.com/send?phone="
 
 fun Activity.startWhatsAppChat(phone: String, packageId: String) {
+    // Only set the intent package if both WhatsApp and WhatsApp Business are installed
+    val shouldSetPackage = this.checkIfWpIsInstalled() && this.checkIfWpBusinessIsInstalled()
     Intent(Intent.ACTION_VIEW).apply {
         data = Uri.parse(WhatsappUri + phone)
-        setPackage(packageId)
+        if (shouldSetPackage) {
+            setPackage(packageId)
+        }
     }.also {
         startActivity(it)
         finish()

--- a/app/src/main/java/dev/theolm/wwc/presentation/extensions/ActivityExt.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/extensions/ActivityExt.kt
@@ -6,9 +6,10 @@ import android.net.Uri
 
 private const val WhatsappUri = "https://api.whatsapp.com/send?phone="
 
-fun Activity.startWhatsAppChat(phone: String) {
+fun Activity.startWhatsAppChat(phone: String, packageId: String) {
     Intent(Intent.ACTION_VIEW).apply {
         data = Uri.parse(WhatsappUri + phone)
+        setPackage(packageId)
     }.also {
         startActivity(it)
         finish()

--- a/app/src/main/java/dev/theolm/wwc/presentation/extensions/ContextExt.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/extensions/ContextExt.kt
@@ -3,18 +3,32 @@ package dev.theolm.wwc.presentation.extensions
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import dev.theolm.wwc.util.WhatsAppPackages
 
-private const val WhatsappPackage = "com.whatsapp"
 fun Context.checkIfWpIsInstalled() =
     runCatching {
         val flags = PackageManager.GET_ACTIVITIES
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             packageManager.getPackageInfo(
-                WhatsappPackage,
+                WhatsAppPackages.Whatsapp,
                 PackageManager.PackageInfoFlags.of(flags.toLong())
             )
         } else {
-            packageManager.getPackageInfo(WhatsappPackage, flags)
+            packageManager.getPackageInfo(WhatsAppPackages.Whatsapp, flags)
+        }
+        true
+    }.getOrElse { false }
+
+fun Context.checkIfWpBusinessIsInstalled() =
+    runCatching {
+        val flags = PackageManager.GET_ACTIVITIES
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.getPackageInfo(
+                WhatsAppPackages.WhatsappBuisness,
+                PackageManager.PackageInfoFlags.of(flags.toLong())
+            )
+        } else {
+            packageManager.getPackageInfo(WhatsAppPackages.WhatsappBuisness, flags)
         }
         true
     }.getOrElse { false }

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/components/ListItems.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/components/ListItems.kt
@@ -1,0 +1,89 @@
+package dev.theolm.wwc.presentation.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.theolm.wwc.R
+
+private val DefaultCornerRadius = 16.dp
+
+@Suppress("ModifierHeightWithText")
+@Composable
+fun SelectableItemList(
+    headlineText: String,
+    supportText: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    ListItem(
+        modifier = Modifier
+            .height(IntrinsicSize.Min)
+            .clip(RoundedCornerShape(DefaultCornerRadius))
+            .clickable(
+                onClick = onClick
+            ),
+        headlineContent = {
+            Text(headlineText)
+        },
+        supportingContent = {
+            Text(supportText)
+        },
+        trailingContent = {
+            SelectableItemListIcon(isSelected = isSelected)
+        }
+    )
+}
+
+@Composable
+private fun SelectableItemListIcon(isSelected: Boolean) {
+    if (isSelected) {
+        Column(
+            modifier = Modifier.fillMaxHeight(),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Check,
+                contentDescription = stringResource(id = R.string.selected_item),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SelectableItemListPreview() {
+    SelectableItemList(
+        headlineText = "Headline",
+        supportText = "Supporting",
+        isSelected = false,
+        onClick = {}
+    )
+}
+
+@Preview
+@Composable
+private fun SelectableItemListSelectedPreview() {
+    SelectableItemList(
+        headlineText = "Headline",
+        supportText = "Supporting",
+        isSelected = true,
+        onClick = {}
+    )
+}

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/components/ListScreen.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/components/ListScreen.kt
@@ -1,0 +1,71 @@
+package dev.theolm.wwc.presentation.ui.components
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+private val DefaultPadding = 16.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ListScreen(
+    title: String,
+    onBackPress: () -> Unit,
+    content: LazyListScope.() -> Unit
+) {
+    val scrollBarBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBarBehavior.nestedScrollConnection),
+        topBar = {
+            DefaultTopAppBar(
+                title = title,
+                scrollBarBehavior = scrollBarBehavior,
+                onBackPress = onBackPress
+            )
+        }
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = it.calculateTopPadding()),
+            contentPadding = PaddingValues(
+                top = DefaultPadding,
+                bottom = 64.dp,
+                start = DefaultPadding,
+                end = DefaultPadding
+            )
+        ) {
+            content()
+        }
+    }
+}
+
+@Suppress("MagicNumber")
+@Preview
+@Composable
+private fun ListScreenPreview() {
+    ListScreen(
+        title = "List Screen",
+        onBackPress = {},
+        content = {
+            items(10) {
+                SelectableItemList(
+                    headlineText = "Headline $it",
+                    supportText = "Supporting $it",
+                    isSelected = it == 1,
+                    onClick = {}
+                )
+            }
+        }
+    )
+}

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/main/MainActivity.kt
@@ -39,6 +39,7 @@ class MainActivity : ComponentActivity(), CoroutineScope by MainScope() {
     }
 
     private fun onStartChatClicked(input: String) = launch {
-        startWhatsAppChat(input)
+        // todo
+        startWhatsAppChat(input, "")
     }
 }

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/main/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import dev.theolm.wwc.domain.models.DefaultApp
 import dev.theolm.wwc.presentation.extensions.checkIfWpIsInstalled
 import dev.theolm.wwc.presentation.extensions.startWhatsAppChat
 import dev.theolm.wwc.presentation.theme.AppTheme
@@ -27,8 +28,8 @@ class MainActivity : ComponentActivity(), CoroutineScope by MainScope() {
                         onDismiss = {
                             finish()
                         },
-                        onStart = {
-                            onStartChatClicked(it)
+                        onStart = { phoneNumber, defaultApp ->
+                            onStartChatClicked(phoneNumber, defaultApp)
                         }
                     )
                 } else {
@@ -38,8 +39,7 @@ class MainActivity : ComponentActivity(), CoroutineScope by MainScope() {
         }
     }
 
-    private fun onStartChatClicked(input: String) = launch {
-        // todo
-        startWhatsAppChat(input, "")
+    private fun onStartChatClicked(input: String, app: DefaultApp) = launch {
+        startWhatsAppChat(input, app.bundleId)
     }
 }

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/main/dialog/input/InputDialogViewModel.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/main/dialog/input/InputDialogViewModel.kt
@@ -1,22 +1,29 @@
 package dev.theolm.wwc.presentation.ui.main.dialog.input
 
 import androidx.lifecycle.ViewModel
-import dev.theolm.wwc.data.datasource.AppDataStore
 import dev.theolm.wwc.domain.models.Country
+import dev.theolm.wwc.domain.models.DefaultApp
+import dev.theolm.wwc.domain.usecase.ObserveSelectedAppUseCase
+import dev.theolm.wwc.domain.usecase.ObserveSelectedCountryUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 
-class InputDialogViewModel(appDataStore: AppDataStore) : ViewModel() {
-    private val settingsFlow = appDataStore.getAppSettings()
+class InputDialogViewModel(
+    observeSelectedAppUseCase: ObserveSelectedAppUseCase,
+    observeSelectedCountryUseCase: ObserveSelectedCountryUseCase,
+) : ViewModel() {
+    private val selectedAppFlow = observeSelectedAppUseCase()
+    private val selectedCountryFlow = observeSelectedCountryUseCase()
     private val inputFlow = MutableStateFlow("")
 
-    val uiState = settingsFlow
-        .combine(inputFlow) { settings, input ->
-            InputDialogUiState(
-                inputField = input,
-                selectedCountryCode = settings.selectedCountryCode
-            )
-        }
+    val uiState = combine(inputFlow, selectedAppFlow, selectedCountryFlow) { input, app, country ->
+        InputDialogUiState(
+            inputField = input,
+            selectedCountryCode = country,
+            selectedApp = app,
+            phoneNumber = country?.code.orEmpty() + input
+        )
+    }
 
     fun onInputChanged(input: String) {
         inputFlow.tryEmit(input)
@@ -25,6 +32,7 @@ class InputDialogViewModel(appDataStore: AppDataStore) : ViewModel() {
 
 data class InputDialogUiState(
     val inputField: String = "",
+    val selectedApp: DefaultApp = DefaultApp.WhatsApp,
     val selectedCountryCode: Country? = null,
-    val phoneNumber: String = selectedCountryCode?.code.orEmpty() + inputField
+    val phoneNumber: String = selectedCountryCode?.code.orEmpty() + inputField,
 )

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/main/dialog/input/PhoneInputDialog.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/main/dialog/input/PhoneInputDialog.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import dev.theolm.wwc.R
 import dev.theolm.wwc.domain.models.Country
+import dev.theolm.wwc.domain.models.DefaultApp
 import dev.theolm.wwc.presentation.extensions.removeInvalidCharacters
 import dev.theolm.wwc.presentation.ui.settings.SettingsActivity
 import org.koin.compose.koinInject
@@ -52,7 +53,7 @@ import org.koin.compose.koinInject
 @Composable
 fun PhoneInputDialog(
     onDismiss: () -> Unit,
-    onStart: (String) -> Unit,
+    onStart: (String, DefaultApp) -> Unit,
     viewModel: InputDialogViewModel = koinInject(),
 ) {
     val uiState by viewModel.uiState.collectAsState(initial = InputDialogUiState())
@@ -62,7 +63,9 @@ fun PhoneInputDialog(
         selectedCountryCode = uiState.selectedCountryCode,
         onDismiss = onDismiss,
         onInputChange = { viewModel.onInputChanged(it) },
-        onStart = onStart
+        onStart = {
+            onStart(uiState.phoneNumber, uiState.selectedApp)
+        }
     )
 }
 
@@ -74,7 +77,7 @@ private fun PhoneInputDialogContent(
     selectedCountryCode: Country?,
     onDismiss: () -> Unit = {},
     onInputChange: (String) -> Unit = {},
-    onStart: (String) -> Unit = {},
+    onStart: () -> Unit = {},
 ) {
     val context = LocalContext.current
     BasicAlertDialog(
@@ -121,12 +124,12 @@ private fun PhoneInputDialogContent(
                             SettingsActivity.startOnCountryCode(context)
                         },
                         onChange = onInputChange,
-                        onDone = { onStart(phoneNumber) }
+                        onDone = onStart
                     )
                     Spacer(modifier = Modifier.height(24.dp))
                     Buttons(
                         onNegative = onDismiss,
-                        onPositive = { onStart(phoneNumber) }
+                        onPositive = onStart
                     )
                 }
             }

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/navigation/Destination.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/navigation/Destination.kt
@@ -8,4 +8,7 @@ interface Destination
 object CountryCodeRoute : Destination
 
 @Serializable
+object DefaultAppRoute : Destination
+
+@Serializable
 object SettingsHomeRoute : Destination

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/SettingsActivity.kt
@@ -1,6 +1,5 @@
 package dev.theolm.wwc.presentation.ui.settings
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -14,12 +13,13 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import dev.theolm.wwc.presentation.theme.AppTheme
 import dev.theolm.wwc.presentation.ui.navigation.CountryCodeRoute
+import dev.theolm.wwc.presentation.ui.navigation.DefaultAppRoute
 import dev.theolm.wwc.presentation.ui.navigation.SettingsHomeRoute
+import dev.theolm.wwc.presentation.ui.settings.defaultapp.DefaultAppPage
 import dev.theolm.wwc.presentation.ui.settings.defaultcode.DefaultCodePage
 import dev.theolm.wwc.presentation.ui.settings.home.SettingsHomePage
 
 class SettingsActivity : ComponentActivity() {
-    @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -38,6 +38,9 @@ class SettingsActivity : ComponentActivity() {
                             onCountryCodeClick = {
                                 navController.navigate(CountryCodeRoute)
                             },
+                            onDefaultAppClick = {
+                                navController.navigate(DefaultAppRoute)
+                            },
                             onBackPress = {
                                 navController.popOrCloseActivity(this@SettingsActivity)
                             }
@@ -45,6 +48,13 @@ class SettingsActivity : ComponentActivity() {
                     }
                     composable<CountryCodeRoute> {
                         DefaultCodePage(
+                            onBackPress = {
+                                navController.popOrCloseActivity(this@SettingsActivity)
+                            }
+                        )
+                    }
+                    composable<DefaultAppRoute> {
+                        DefaultAppPage(
                             onBackPress = {
                                 navController.popOrCloseActivity(this@SettingsActivity)
                             }

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultapp/DefaultAppPage.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultapp/DefaultAppPage.kt
@@ -22,7 +22,9 @@ fun DefaultAppPage(
     DefaultAppPageContent(
         onBackPress = onBackPress,
         selectedApp = uiState.selectedApp,
-        onAppSelect = {}
+        onAppSelect = {
+            viewModel.onAppSelected(it)
+        }
     )
 }
 

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultapp/DefaultAppPage.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultapp/DefaultAppPage.kt
@@ -1,0 +1,71 @@
+package dev.theolm.wwc.presentation.ui.settings.defaultapp
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import dev.theolm.wwc.R
+import dev.theolm.wwc.domain.models.DefaultApp
+import dev.theolm.wwc.presentation.ui.components.ListScreen
+import dev.theolm.wwc.presentation.ui.components.SelectableItemList
+import dev.theolm.wwc.util.WhatsAppPackages
+import org.koin.compose.koinInject
+
+@Composable
+fun DefaultAppPage(
+    onBackPress: () -> Unit,
+    viewModel: DefaultAppViewModel = koinInject(),
+) {
+    val uiState by viewModel.uiState.collectAsState(initial = DefaultAppUiState())
+
+    DefaultAppPageContent(
+        onBackPress = onBackPress,
+        selectedApp = uiState.selectedApp,
+        onAppSelect = {}
+    )
+}
+
+@Composable
+private fun DefaultAppPageContent(
+    onBackPress: () -> Unit,
+    onAppSelect: (DefaultApp) -> Unit,
+    selectedApp: DefaultApp,
+) {
+    ListScreen(
+        title = stringResource(id = R.string.select_app_page_title),
+        onBackPress = onBackPress
+    ) {
+        item {
+            SelectableItemList(
+                headlineText = stringResource(id = R.string.select_app_wp),
+                supportText = WhatsAppPackages.Whatsapp,
+                isSelected = selectedApp == DefaultApp.WhatsApp,
+                onClick = {
+                    onAppSelect(DefaultApp.WhatsApp)
+                }
+            )
+        }
+
+        item {
+            SelectableItemList(
+                headlineText = stringResource(id = R.string.select_app_wp4b),
+                supportText = WhatsAppPackages.WhatsappBuisness,
+                isSelected = selectedApp == DefaultApp.WhatsAppBusiness,
+                onClick = {
+                    onAppSelect(DefaultApp.WhatsAppBusiness)
+                }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DefaultAppPagePreview() {
+    DefaultAppPageContent(
+        onBackPress = {},
+        selectedApp = DefaultApp.WhatsApp,
+        onAppSelect = {}
+    )
+}

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultapp/DefaultAppViewModel.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultapp/DefaultAppViewModel.kt
@@ -1,16 +1,31 @@
 package dev.theolm.wwc.presentation.ui.settings.defaultapp
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dev.theolm.wwc.domain.models.DefaultApp
-import dev.theolm.wwc.domain.usecase.ObserveSettingsUseCase
-import kotlinx.coroutines.flow.MutableStateFlow
+import dev.theolm.wwc.domain.usecase.ObserveSelectedAppUseCase
+import dev.theolm.wwc.domain.usecase.UpdateSelectedAppUseCase
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
 class DefaultAppViewModel(
-    observeSettingsUseCase: ObserveSettingsUseCase
+    observeSelectedAppUseCase: ObserveSelectedAppUseCase,
+    private val updateSelectedAppUseCase: UpdateSelectedAppUseCase,
 ) : ViewModel() {
-    val uiState = MutableStateFlow(DefaultAppUiState())
+    private val selectedAppFlow = observeSelectedAppUseCase()
+    val uiState = selectedAppFlow.map {
+        DefaultAppUiState(
+            selectedApp = it
+        )
+    }
+
+    fun onAppSelected(defaultApp: DefaultApp) {
+        viewModelScope.launch {
+            updateSelectedAppUseCase(defaultApp)
+        }
+    }
 }
 
 data class DefaultAppUiState(
-    val selectedApp: DefaultApp = DefaultApp.WhatsApp
+    val selectedApp: DefaultApp = DefaultApp.WhatsApp,
 )

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultapp/DefaultAppViewModel.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultapp/DefaultAppViewModel.kt
@@ -1,0 +1,16 @@
+package dev.theolm.wwc.presentation.ui.settings.defaultapp
+
+import androidx.lifecycle.ViewModel
+import dev.theolm.wwc.domain.models.DefaultApp
+import dev.theolm.wwc.domain.usecase.ObserveSettingsUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class DefaultAppViewModel(
+    observeSettingsUseCase: ObserveSettingsUseCase
+) : ViewModel() {
+    val uiState = MutableStateFlow(DefaultAppUiState())
+}
+
+data class DefaultAppUiState(
+    val selectedApp: DefaultApp = DefaultApp.WhatsApp
+)

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultcode/DefaultCodePage.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/defaultcode/DefaultCodePage.kt
@@ -1,44 +1,17 @@
 package dev.theolm.wwc.presentation.ui.settings.defaultcode
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import dev.theolm.wwc.R
 import dev.theolm.wwc.domain.models.Country
-import dev.theolm.wwc.presentation.ui.components.DefaultTopAppBar
+import dev.theolm.wwc.presentation.ui.components.ListScreen
+import dev.theolm.wwc.presentation.ui.components.SelectableItemList
 import org.koin.compose.koinInject
 
-private val DefaultPadding = 16.dp
-private val DefaultCornerRadius = 16.dp
-
-@Suppress("ModifierHeightWithText")
 @Composable
 fun DefaultCodePage(
     onBackPress: () -> Unit,
@@ -54,107 +27,36 @@ fun DefaultCodePage(
     )
 }
 
-@Suppress("ModifierHeightWithText")
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DefaultCodePageContent(
+private fun DefaultCodePageContent(
     selectedCountry: Country?,
     countries: List<Country>,
     onBackPress: () -> Unit = {},
     onCountrySelect: (Country?) -> Unit = {},
 ) {
-    val scrollBarBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-    Scaffold(
-        modifier = Modifier.nestedScroll(scrollBarBehavior.nestedScrollConnection),
-        topBar = {
-            DefaultTopAppBar(
-                title = stringResource(id = R.string.country_code_page_title),
-                scrollBarBehavior = scrollBarBehavior,
-                onBackPress = onBackPress
-            )
-        }
+    ListScreen(
+        title = stringResource(id = R.string.country_code_page_title),
+        onBackPress = onBackPress
     ) {
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = it.calculateTopPadding()),
-            contentPadding = PaddingValues(
-                top = DefaultPadding,
-                bottom = 64.dp,
-                start = DefaultPadding,
-                end = DefaultPadding
+        item {
+            SelectableItemList(
+                headlineText = stringResource(id = R.string.no_default_code),
+                supportText = stringResource(id = R.string.no_default_code_support),
+                isSelected = selectedCountry == null,
+                onClick = {
+                    onCountrySelect(null)
+                }
             )
-        ) {
-            item {
-                ListItem(
-                    modifier = Modifier
-                        .height(IntrinsicSize.Min)
-                        .clip(RoundedCornerShape(DefaultCornerRadius))
-                        .clickable {
-                            onCountrySelect(null)
-                        },
-                    headlineContent = {
-                        Text(stringResource(id = R.string.no_default_code))
-                    },
-                    supportingContent = {
-                        Text(stringResource(id = R.string.no_default_code_support))
-                    },
-                    trailingContent = {
-                        SelectedIcon(isSelected = selectedCountry == null)
-                    }
-                )
-            }
-
-            items(countries) { country ->
-                ListItem(
-                    country = country,
-                    isSelected = country == selectedCountry,
-                    onClick = {
-                        onCountrySelect(country)
-                    }
-                )
-            }
         }
-    }
-}
 
-@Suppress("ModifierHeightWithText")
-@Composable
-private fun ListItem(
-    country: Country,
-    isSelected: Boolean,
-    onClick: () -> Unit,
-) {
-    ListItem(
-        modifier = Modifier
-            .height(IntrinsicSize.Min)
-            .clip(RoundedCornerShape(DefaultCornerRadius))
-            .clickable(
-                onClick = onClick
-            ),
-        headlineContent = {
-            Text(stringResource(id = country.name))
-        },
-        supportingContent = {
-            Text(country.code)
-        },
-        trailingContent = {
-            SelectedIcon(isSelected = isSelected)
-        }
-    )
-}
-
-@Composable
-private fun SelectedIcon(isSelected: Boolean) {
-    if (isSelected) {
-        Column(
-            modifier = Modifier.fillMaxHeight(),
-            verticalArrangement = Arrangement.Center,
-        ) {
-            Icon(
-                imageVector = Icons.Filled.Check,
-                contentDescription = stringResource(id = R.string.selected_item),
-                tint = MaterialTheme.colorScheme.primary
+        items(countries) { country ->
+            SelectableItemList(
+                headlineText = stringResource(id = country.name),
+                supportText = country.code,
+                isSelected = country == selectedCountry,
+                onClick = {
+                    onCountrySelect(country)
+                }
             )
         }
     }

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsHomePage.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsHomePage.kt
@@ -27,6 +27,7 @@ import dev.theolm.wwc.domain.models.DefaultApp
 import dev.theolm.wwc.presentation.extensions.checkIfWpBusinessIsInstalled
 import dev.theolm.wwc.presentation.extensions.checkIfWpIsInstalled
 import dev.theolm.wwc.presentation.ui.components.DefaultTopAppBar
+import dev.theolm.wwc.presentation.ui.components.ListScreen
 import org.koin.compose.koinInject
 
 @Composable
@@ -49,7 +50,6 @@ fun SettingsHomePage(
 }
 
 @Suppress("LongParameterList")
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SettingsHomePageContent(
     onBackPress: () -> Unit,
@@ -59,50 +59,36 @@ private fun SettingsHomePageContent(
     onDefaultAppClick: () -> Unit,
     showAppSelection: Boolean,
 ) {
-    val scrollBarBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-    Scaffold(
-        modifier = Modifier.nestedScroll(scrollBarBehavior.nestedScrollConnection),
-        topBar = {
-            DefaultTopAppBar(
-                title = stringResource(id = R.string.settings),
-                scrollBarBehavior = scrollBarBehavior,
-                onBackPress = onBackPress
+    ListScreen(
+        title = stringResource(id = R.string.settings),
+        onBackPress = onBackPress
+    ) {
+        item {
+            val support = selectedCountryCode?.let { country ->
+                "${stringResource(id = country.name)} (${country.code})"
+            } ?: stringResource(id = R.string.no_code_selected)
+            SettingsItem(
+                headline = stringResource(id = R.string.select_code_headline),
+                supporting = support,
+                overline = stringResource(id = R.string.select_code_overline),
+                onClick = onCountryCodeClick
             )
         }
-    ) {
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = it.calculateTopPadding()),
-            contentPadding = PaddingValues(top = 16.dp, bottom = 64.dp, start = 16.dp, end = 16.dp)
-        ) {
-            item {
-                val support = selectedCountryCode?.let { country ->
-                    "${stringResource(id = country.name)} (${country.code})"
-                } ?: stringResource(id = R.string.no_code_selected)
-                SettingsItem(
-                    headline = stringResource(id = R.string.select_code_headline),
-                    supporting = support,
-                    overline = stringResource(id = R.string.select_code_overline),
-                    onClick = onCountryCodeClick
-                )
+
+        if (showAppSelection) {
+            val supportTextRes = if (selectedApp == DefaultApp.WhatsApp) {
+                R.string.select_app_wp
+            } else {
+                R.string.select_app_wp4b
             }
 
-            if (showAppSelection) {
-                val supportTextRes = if (selectedApp == DefaultApp.WhatsApp) {
-                    R.string.select_app_wp
-                } else {
-                    R.string.select_app_wp4b
-                }
-
-                item {
-                    SettingsItem(
-                        headline = stringResource(id = R.string.select_app_headline),
-                        supporting = stringResource(id = supportTextRes),
-                        overline = stringResource(id = R.string.select_app_overline),
-                        onClick = onDefaultAppClick
-                    )
-                }
+            item {
+                SettingsItem(
+                    headline = stringResource(id = R.string.select_app_headline),
+                    supporting = stringResource(id = supportTextRes),
+                    overline = stringResource(id = R.string.select_app_overline),
+                    onClick = onDefaultAppClick
+                )
             }
         }
     }

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsHomePage.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsHomePage.kt
@@ -1,22 +1,14 @@
 package dev.theolm.wwc.presentation.ui.settings.home
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -26,7 +18,6 @@ import dev.theolm.wwc.domain.models.Country
 import dev.theolm.wwc.domain.models.DefaultApp
 import dev.theolm.wwc.presentation.extensions.checkIfWpBusinessIsInstalled
 import dev.theolm.wwc.presentation.extensions.checkIfWpIsInstalled
-import dev.theolm.wwc.presentation.ui.components.DefaultTopAppBar
 import dev.theolm.wwc.presentation.ui.components.ListScreen
 import org.koin.compose.koinInject
 

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsHomePage.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsHomePage.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.theolm.wwc.R
 import dev.theolm.wwc.domain.models.Country
+import dev.theolm.wwc.domain.models.DefaultApp
 import dev.theolm.wwc.presentation.extensions.checkIfWpBusinessIsInstalled
 import dev.theolm.wwc.presentation.extensions.checkIfWpIsInstalled
 import dev.theolm.wwc.presentation.ui.components.DefaultTopAppBar
@@ -42,14 +43,17 @@ fun SettingsHomePage(
         selectedCountryCode = uiState.selectedCountryCode,
         onCountryCodeClick = onCountryCodeClick,
         showAppSelection = showAppSelector,
-        onDefaultAppClick = onDefaultAppClick
+        onDefaultAppClick = onDefaultAppClick,
+        selectedApp = uiState.selectedApp
     )
 }
 
+@Suppress("LongParameterList")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SettingsHomePageContent(
     onBackPress: () -> Unit,
+    selectedApp: DefaultApp,
     selectedCountryCode: Country?,
     onCountryCodeClick: () -> Unit,
     onDefaultAppClick: () -> Unit,
@@ -85,10 +89,16 @@ private fun SettingsHomePageContent(
             }
 
             if (showAppSelection) {
+                val supportTextRes = if (selectedApp == DefaultApp.WhatsApp) {
+                    R.string.select_app_wp
+                } else {
+                    R.string.select_app_wp4b
+                }
+
                 item {
                     SettingsItem(
                         headline = stringResource(id = R.string.select_app_headline),
-                        supporting = stringResource(id = R.string.select_app_wp),
+                        supporting = stringResource(id = supportTextRes),
                         overline = stringResource(id = R.string.select_app_overline),
                         onClick = onDefaultAppClick
                     )
@@ -133,7 +143,8 @@ private fun Preview() {
         selectedCountryCode = Country(R.string.brazil, "+55"),
         onCountryCodeClick = {},
         showAppSelection = true,
-        onDefaultAppClick = {}
+        onDefaultAppClick = {},
+        selectedApp = DefaultApp.WhatsApp
     )
 }
 

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsHomePage.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsHomePage.kt
@@ -17,25 +17,32 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.theolm.wwc.R
 import dev.theolm.wwc.domain.models.Country
+import dev.theolm.wwc.presentation.extensions.checkIfWpBusinessIsInstalled
+import dev.theolm.wwc.presentation.extensions.checkIfWpIsInstalled
 import dev.theolm.wwc.presentation.ui.components.DefaultTopAppBar
 import org.koin.compose.koinInject
 
 @Composable
 fun SettingsHomePage(
     onCountryCodeClick: () -> Unit,
+    onDefaultAppClick: () -> Unit,
     onBackPress: () -> Unit,
     viewModel: SettingsViewModel = koinInject(),
 ) {
     val uiState by viewModel.uiState.collectAsState(initial = SettingsUiState())
+    val showAppSelector = showAppSelector()
     SettingsHomePageContent(
         onBackPress = onBackPress,
         selectedCountryCode = uiState.selectedCountryCode,
-        onCountryCodeClick = onCountryCodeClick
+        onCountryCodeClick = onCountryCodeClick,
+        showAppSelection = showAppSelector,
+        onDefaultAppClick = onDefaultAppClick
     )
 }
 
@@ -45,6 +52,8 @@ private fun SettingsHomePageContent(
     onBackPress: () -> Unit,
     selectedCountryCode: Country?,
     onCountryCodeClick: () -> Unit,
+    onDefaultAppClick: () -> Unit,
+    showAppSelection: Boolean,
 ) {
     val scrollBarBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
@@ -73,6 +82,17 @@ private fun SettingsHomePageContent(
                     overline = stringResource(id = R.string.select_code_overline),
                     onClick = onCountryCodeClick
                 )
+            }
+
+            if (showAppSelection) {
+                item {
+                    SettingsItem(
+                        headline = stringResource(id = R.string.select_app_headline),
+                        supporting = stringResource(id = R.string.select_app_wp),
+                        overline = stringResource(id = R.string.select_app_overline),
+                        onClick = onDefaultAppClick
+                    )
+                }
             }
         }
     }
@@ -111,6 +131,14 @@ private fun Preview() {
     SettingsHomePageContent(
         onBackPress = {},
         selectedCountryCode = Country(R.string.brazil, "+55"),
-        onCountryCodeClick = {}
+        onCountryCodeClick = {},
+        showAppSelection = true,
+        onDefaultAppClick = {}
     )
+}
+
+@Composable
+private fun showAppSelector(): Boolean {
+    val context = LocalContext.current
+    return context.checkIfWpIsInstalled() && context.checkIfWpBusinessIsInstalled()
 }

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsViewModel.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package dev.theolm.wwc.presentation.ui.settings.home
 
 import androidx.lifecycle.ViewModel
 import dev.theolm.wwc.domain.models.Country
+import dev.theolm.wwc.domain.models.DefaultApp
 import dev.theolm.wwc.domain.usecase.ObserveSettingsUseCase
 import kotlinx.coroutines.flow.map
 
@@ -9,11 +10,13 @@ class SettingsViewModel(observeSettings: ObserveSettingsUseCase) : ViewModel() {
     private val settingsFlow = observeSettings()
     val uiState = settingsFlow.map { settings ->
         SettingsUiState(
-            selectedCountryCode = settings.selectedCountryCode
+            selectedCountryCode = settings.selectedCountryCode,
+            selectedApp = settings.defaultApp
         )
     }
 }
 
 data class SettingsUiState(
     val selectedCountryCode: Country? = null,
+    val selectedApp: DefaultApp = DefaultApp.WhatsApp,
 )

--- a/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsViewModel.kt
+++ b/app/src/main/java/dev/theolm/wwc/presentation/ui/settings/home/SettingsViewModel.kt
@@ -2,14 +2,14 @@ package dev.theolm.wwc.presentation.ui.settings.home
 
 import androidx.lifecycle.ViewModel
 import dev.theolm.wwc.domain.models.Country
-import dev.theolm.wwc.domain.usecase.ObserveSelectedCountryUseCase
+import dev.theolm.wwc.domain.usecase.ObserveSettingsUseCase
 import kotlinx.coroutines.flow.map
 
-class SettingsViewModel(observeSelectedCountry: ObserveSelectedCountryUseCase) : ViewModel() {
-    private val selectedCountryFlow = observeSelectedCountry()
-    val uiState = selectedCountryFlow.map { countryCode ->
+class SettingsViewModel(observeSettings: ObserveSettingsUseCase) : ViewModel() {
+    private val settingsFlow = observeSettings()
+    val uiState = settingsFlow.map { settings ->
         SettingsUiState(
-            selectedCountryCode = countryCode
+            selectedCountryCode = settings.selectedCountryCode
         )
     }
 }

--- a/app/src/main/java/dev/theolm/wwc/util/WhatsAppPackages.kt
+++ b/app/src/main/java/dev/theolm/wwc/util/WhatsAppPackages.kt
@@ -1,0 +1,6 @@
+package dev.theolm.wwc.util
+
+object WhatsAppPackages {
+    const val Whatsapp = "com.whatsapp"
+    const val WhatsappBuisness = "com.whatsapp.w4b"
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -25,9 +25,14 @@
     <string name="select_code_overline">Código de país</string>
 
     <!--  Country code dialog texts   -->
+    <string name="select_app_overline">Aplicación predeterminada</string>
+    <string name="select_app_headline">Seleccione la aplicación predeterminada</string>
+    <string name="select_app_wp">Usar WhatsApp</string>
+    <string name="select_app_wp4b">Usar WhatsApp Business</string>
     <string name="country_code_page_title">Código de país</string>
     <string name="default_code">Código de país predeterminado</string>
     <string name="selected_item">Elemento seleccionado</string>
     <string name="no_default_code">Sin código predeterminado</string>
     <string name="no_default_code_support">Eliminar el código predeterminado</string>
+    <string name="select_app_page_title">Aplicación predeterminada</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -29,6 +29,11 @@
     <string name="selected_item">Item selecionado</string>
     <string name="no_default_code">Sem código padrão</string>
     <string name="no_default_code_support">Remove o código padrão</string>
+    <string name="select_app_overline">App padrão</string>
+    <string name="select_app_headline">Selecione o aplicativo padrão</string>
+    <string name="select_app_wp">Use o WhatsApp</string>
+    <string name="select_app_wp4b">Use o WhatsApp Business</string>
     <string name="country_code_page_title">Código do país</string>
+    <string name="select_app_page_title">App padrão</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,10 @@
     <string name="no_code_selected">No code selected yet</string>
     <string name="select_code_headline">Select the default country code</string>
     <string name="select_code_overline">Country code</string>
+    <string name="select_app_overline">Default app</string>
+    <string name="select_app_headline">Select the default application</string>
+    <string name="select_app_wp">Use WhatsApp</string>
+    <string name="select_app_wp4b">Use WhatsApp Business</string>
 
     <!--  Country code dialog texts   -->
     <string name="country_code_page_title">Country code</string>
@@ -32,4 +36,9 @@
     <string name="selected_item">Selected item</string>
     <string name="no_default_code">No default code</string>
     <string name="no_default_code_support">Remove the default code</string>
+
+    <!--  Select app page   -->
+    <string name="select_app_page_title">Default app</string>
+    <string name="select_app_page_wp" translatable="false">WhatsApp</string>
+    <string name="select_app_page_wp4b" translatable="false">WhatsApp Business</string>
 </resources>


### PR DESCRIPTION
This PR introduces support for users who have both WhatsApp and WhatsApp Business installed. The main features include:

- **Single App Installation**: If the user has only WhatsApp or WhatsApp Business installed, the app will start the chat with the installed app.
- **Dual App Installation**: If both apps are installed, the default option is to use regular WhatsApp.
- **Settings Menu Option**: A new option in the settings menu allows users to choose between using WhatsApp or WhatsApp Business. This menu is visible only when both apps are installed.

This update resolves issue #17.
