### PR TITLE
Adding share number feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,13 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/plain"/>
+            </intent-filter>
+
         </activity>
 
         <activity

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,22 @@
 [versions]
-androidGradlePlugin = "8.4.1"
+androidGradlePlugin = "8.4.2"
 kotlin = "2.0.0"
 androidxCore = "1.13.1"
 androidxAppCompat = "1.7.0"
 androidMaterial = "1.12.0"
 androidxActivity = "1.9.0"
-androidxLifecycle = "2.8.1"
+androidxLifecycle = "2.8.3"
 accompanist = "0.34.0"
-androidxComposeBom = "2024.05.00"
-androidxComposeMaterial3 = "1.3.0-beta02"
+androidxComposeBom = "2024.06.00"
+androidxComposeMaterial3 = "1.3.0-beta04"
 detektPlugin = "1.23.6"
 detektComposeRule = "1.3.0"
 datastore = "1.1.1"
-koin = "3.6.0-Beta4"
-composeNavigation = "2.8.0-beta02"
+koin = "3.6.0-wasm-alpha2"
+composeNavigation = "2.8.0-beta05"
 serializationJson = "1.6.3"
 immutableCollections = "0.3.7"
+junit = "4.13.2"
 
 [libraries]
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
@@ -29,6 +30,9 @@ androidx-protoDataStore = { module = "androidx.datastore:datastore", version.ref
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidx-viewModelCompose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycleRuntimeCompose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+
+junit = { module = "junit:junit", version.ref = "junit" }
+
 
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidxComposeBom" }
 compose-foundation = { module = "androidx.compose.foundation:foundation" }

--- a/modules/presentation/build.gradle.kts
+++ b/modules/presentation/build.gradle.kts
@@ -44,5 +44,7 @@ dependencies {
     implementation(libs.koin.core)
     implementation(libs.koin.compose)
 
+    testImplementation(libs.junit)
+
     debugImplementation(libs.compose.uiTooling)
 }

--- a/modules/presentation/src/main/kotlin/dev/theolm/wwc/presentation/ext/IntentExt.kt
+++ b/modules/presentation/src/main/kotlin/dev/theolm/wwc/presentation/ext/IntentExt.kt
@@ -1,0 +1,34 @@
+package dev.theolm.wwc.presentation.ext
+
+import android.content.Intent
+
+/**
+ * Extracts the shared phone number from the intent.
+ * @return the shared phone number or null if it's not a phone number.
+ */
+fun Intent.getSharedPhoneNumber(): String? {
+    return runCatching {
+        val clipDataText = this.clipData?.getItemAt(0)?.text ?: return null
+        clipDataText.extractPhoneNumber()
+    }.getOrNull()
+}
+
+internal fun CharSequence.extractPhoneNumber(): String {
+    return this.toString()
+        .treatForChromeShare()
+        .numbersOnly()
+}
+
+/**
+ * Treats the shared text from Chrome share.
+ *
+ * Chrome shares the selected text plus the page title and URL.
+ * This function returns only the selected text.
+ */
+private fun String.treatForChromeShare(): String {
+    return this.split("\n").firstOrNull().orEmpty()
+}
+
+private fun String.numbersOnly(): String {
+    return this.replace("[^0-9]".toRegex(), "")
+}

--- a/modules/presentation/src/main/kotlin/dev/theolm/wwc/presentation/ui/dialog/MainActivity.kt
+++ b/modules/presentation/src/main/kotlin/dev/theolm/wwc/presentation/ui/dialog/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import dev.theolm.wwc.domain.models.DefaultApp
 import dev.theolm.wwc.presentation.ext.checkIfWpBusinessIsInstalled
 import dev.theolm.wwc.presentation.ext.checkIfWpIsInstalled
+import dev.theolm.wwc.presentation.ext.getSharedPhoneNumber
 import dev.theolm.wwc.presentation.ext.startWhatsAppChat
 import dev.theolm.wwc.presentation.ui.dialog.error.ErrorDialog
 import dev.theolm.wwc.presentation.ui.dialog.phoneinput.PhoneInputDialog
@@ -26,6 +27,7 @@ class MainActivity : ComponentActivity(), CoroutineScope by MainScope() {
             ) {
                 if (checkIfWpIsInstalled() || checkIfWpBusinessIsInstalled()) {
                     PhoneInputDialog(
+                        initialNumber = intent.getSharedPhoneNumber(),
                         onDismiss = {
                             finish()
                         },

--- a/modules/presentation/src/main/kotlin/dev/theolm/wwc/presentation/ui/dialog/phoneinput/PhoneInputDialog.kt
+++ b/modules/presentation/src/main/kotlin/dev/theolm/wwc/presentation/ui/dialog/phoneinput/PhoneInputDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -54,11 +55,11 @@ import org.koin.compose.koinInject
 fun PhoneInputDialog(
     onDismiss: () -> Unit,
     onStart: (String, DefaultApp) -> Unit,
+    initialNumber: String? = null,
     viewModel: InputDialogViewModel = koinInject(),
 ) {
     val uiState by viewModel.uiState.collectAsState(initial = InputDialogUiState())
     PhoneInputDialogContent(
-        phoneNumber = uiState.phoneNumber,
         inputField = uiState.inputField,
         selectedCountryCode = uiState.selectedCountryCode,
         onDismiss = onDismiss,
@@ -67,12 +68,17 @@ fun PhoneInputDialog(
             onStart(uiState.phoneNumber, uiState.selectedApp)
         }
     )
+
+    LaunchedEffect(key1 = initialNumber) {
+        if (initialNumber != null) {
+            viewModel.onInputChanged(initialNumber)
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun PhoneInputDialogContent(
-    phoneNumber: String,
     inputField: String,
     selectedCountryCode: Country?,
     onDismiss: () -> Unit = {},
@@ -227,7 +233,6 @@ private fun CountryCodeField(
 @Composable
 private fun Preview() {
     PhoneInputDialogContent(
-        phoneNumber = "",
         inputField = "",
         selectedCountryCode = Country(R.string.brazil, "+55"),
         onDismiss = {},
@@ -240,7 +245,6 @@ private fun Preview() {
 @Composable
 private fun PreviewPt() {
     PhoneInputDialogContent(
-        phoneNumber = "",
         inputField = "",
         selectedCountryCode = Country(R.string.brazil, "+55"),
         onDismiss = {},

--- a/modules/presentation/src/test/kotlin/dev/theolm/wwc/presentation/ext/ExtractPhoneNumberTest.kt
+++ b/modules/presentation/src/test/kotlin/dev/theolm/wwc/presentation/ext/ExtractPhoneNumberTest.kt
@@ -1,0 +1,42 @@
+package dev.theolm.wwc.presentation.ext
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@Suppress("all")
+class ExtractPhoneNumberTest {
+    @Test
+    fun `given a String with 51992088821 - expects 51992088821`() {
+        val input = "51992088821"
+
+        val result = input.extractPhoneNumber()
+
+        assertEquals("51992088821", result)
+    }
+
+    @Test
+    fun `given a String with 51992088821withRandomText - expects 51992088821`() {
+        val input = "51992088821withRandomText"
+
+        val result = input.extractPhoneNumber()
+
+        assertEquals("51992088821", result)
+    }
+
+    @Test
+    fun `given a String with only text - expects empty string`() {
+        val input = "StringWithOnlyText"
+
+        val result = input.extractPhoneNumber()
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `given a string shared from chrome - expects to extract only the selected number`() {
+        val chromeString = "\"0800 722 7152\"\n" +
+            " https://www.google.com/search?q=n%C3%BAmero+de+telefone&oq=numero+de+te&gs_lcrp=EgZjaHJvbWUqCggBEAAYiwMYgAQyBggAEEUYOTIKCAEQABiLAxiABDIKCAIQABiLAxiABDIKCAMQABiLAxiABDIKCAQQABiLAxiABDIHCAUQABiABDIHCAYQABiABDIHCAcQABiABDIHCAgQABiABDIHCAkQABiABDIHCAoQABiABDIHCAsQABiABDIHCAwQABiABDIHCA0QABiABDIHCA4QABiABNIBCDY0ODRqMWo0qAIBsAIB&client=ms-android-xiaomi-rev1&sourceid=chrome-mobile&ie=UTF-8#:~:text=HDI%20Seguros%20%C2%B7-,0800%20722%207152,-%C2%B7%200800%20775%204036"
+
+        val result = chromeString.extractPhoneNumber()
+        assertEquals("08007227152", result)
+    }
+}


### PR DESCRIPTION
- The user can now select a text (in any other app) and shareit  with ChatLauncher. If this text is a number it will automatically fill the phone input.
- There are edge cases (like Chrome) where the selected text is not the only thing shared. Chrome adds a bunch of extra stuff in the intent. The app will try to remove the garbage and level only the number.