### PR TITLE
Replacing universal link for deeplink

### DIFF
--- a/app/src/main/java/dev/theolm/wwc/ext/ActivityExt.kt
+++ b/app/src/main/java/dev/theolm/wwc/ext/ActivityExt.kt
@@ -4,13 +4,14 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 
-private const val WhatsappUri = "https://api.whatsapp.com/send?phone="
+// private const val WhatsappUri = "https://api.whatsapp.com/send?phone="
+private const val WhatsappUri2 = "whatsapp://send/?"
 
 fun Activity.startWhatsAppChat(phone: String, packageId: String) {
     // Only set the intent package if both WhatsApp and WhatsApp Business are installed
     val shouldSetPackage = this.checkIfWpIsInstalled() && this.checkIfWpBusinessIsInstalled()
     Intent(Intent.ACTION_VIEW).apply {
-        data = Uri.parse(dev.theolm.wwc.ext.WhatsappUri + phone)
+        data = Uri.parse(WhatsappUri2 + phone)
         if (shouldSetPackage) {
             setPackage(packageId)
         }


### PR DESCRIPTION
In order to avoid issues with different OS this PR replaces the universal link `https://api.whatsapp.com/send?phone=`
for the direct deeplink `whatsapp://send/?`

Everything should work the same, but this change requires testing, especially with WhatsApp business.