### PR TITLE
Disable RTL support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
+        android:supportsRtl="false"
         android:theme="@style/Theme.wwc"
         tools:targetApi="31">
         <activity


### PR DESCRIPTION
This pull request makes a small change to the `AndroidManifest.xml` file, disabling right-to-left (RTL) layout support for the application. This means the app will no longer automatically mirror its layout for RTL languages.

- Disabled RTL layout support by setting `android:supportsRtl` to `false` in `AndroidManifest.xml`.

closes #166 