### PR TITLE
Minified release build to reduce APK size!

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,7 @@ android {
     buildTypes {
         release {
             signingConfig = signingConfigs.getByName("release")
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
Right now isMinifyEnabled option in app/gradle is set to false, due to which release APK size is too large 15.4MB! After setting this option to true - release build is only 3.6MB
<img width="656" height="202" alt="20251010_21h57m17s_grim" src="https://github.com/user-attachments/assets/0295175a-1aea-4f31-8236-9f44a60407f9" />

<img width="1346" height="108" alt="20251010_21h57m59s_grim" src="https://github.com/user-attachments/assets/592fca3b-c5c4-49d5-a654-5f36d76c429b" />
